### PR TITLE
Add more options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,4 @@
 # The maximum percentage of RAM to be used for the Zswap pool.
 zswap_max_pool_percent: 20
 zswap_compressor: "lz4"
+zswap_zpool: zbud

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,4 @@
 zswap_max_pool_percent: 20
 zswap_compressor: "lz4"
 zswap_zpool: zbud
+zswap_accept_threshold_percent: 90

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,11 @@
 ---
+# Control if zswap should be applied right now or on next reboot
+zswap_wait_for_reboot: false
 # The maximum percentage of RAM to be used for the Zswap pool.
 zswap_max_pool_percent: 20
+# The used compression algorithm
 zswap_compressor: "lz4"
+# The type of page storage used, see https://docs.kernel.org/admin-guide/mm/zswap.html
 zswap_zpool: zbud
+# Lower watermark for using zswap again when it filled up
 zswap_accept_threshold_percent: 90

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 # The maximum percentage of RAM to be used for the Zswap pool.
 zswap_max_pool_percent: 20
+zswap_compressor: "lz4"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,3 +34,21 @@
     backrefs: yes
   notify:
     - update-grub
+
+- name: set compressor (insert)
+  lineinfile:
+    path: '{{ zswap_grubfile }}'
+    regexp: '^GRUB_CMDLINE_LINUX_DEFAULT="((?!.*?zswap\.compressor=[a-z0-9]+).*)"'
+    line: 'GRUB_CMDLINE_LINUX_DEFAULT="\1 zswap.compressor={{ zswap_compressor }}"'
+    backrefs: yes
+  notify:
+    - update-grub
+
+- name: set compressor (update)
+  lineinfile:
+    path: '{{ zswap_grubfile }}'
+    regexp: '^GRUB_CMDLINE_LINUX_DEFAULT="(.*?)zswap\.compressor=[0-9]+(.*?)"'
+    line: 'GRUB_CMDLINE_LINUX_DEFAULT="\1zswap.compressor={{ zswap_compressor }}\2"'
+    backrefs: yes
+  notify:
+    - update-grub

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -88,3 +88,12 @@
     backrefs: yes
   notify:
     - update-grub
+
+- name: enable zswap right away
+  shell:
+    cmd: |
+      echo {{ zswap_zpool }} > /sys/module/zswap/parameters/zpool;
+      echo {{ zswap_compressor }} > /sys/module/zswap/parameters/compressor;
+      echo {{ zswap_accept_threshold_percent }} > /sys/module/zswap/parameters/accept_threshold_percent;
+      echo 1 > /sys/module/zswap/parameters/enabled;
+  when: not zswap_wait_for_reboot

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -70,3 +70,21 @@
     backrefs: yes
   notify:
     - update-grub
+
+- name: set accept_threshold_percent (insert)
+  lineinfile:
+    path: '{{ zswap_grubfile }}'
+    regexp: '^GRUB_CMDLINE_LINUX_DEFAULT="((?!.*?zswap\.accept_threshold_percent=[A-z]+).*)"'
+    line: 'GRUB_CMDLINE_LINUX_DEFAULT="\1 zswap.accept_threshold_percent={{ zswap_accept_threshold_percent }}"'
+    backrefs: yes
+  notify:
+    - update-grub
+
+- name: set accept_threshold_percent (update)
+  lineinfile:
+    path: '{{ zswap_grubfile }}'
+    regexp: '^GRUB_CMDLINE_LINUX_DEFAULT="(.*?)zswap\.accept_threshold_percent=[A-z]+(.*?)"'
+    line: 'GRUB_CMDLINE_LINUX_DEFAULT="\1zswap.accept_threshold_percent={{ zswap_accept_threshold_percent }}\2"'
+    backrefs: yes
+  notify:
+    - update-grub

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,3 +52,21 @@
     backrefs: yes
   notify:
     - update-grub
+
+- name: set zpool (insert)
+  lineinfile:
+    path: '{{ zswap_grubfile }}'
+    regexp: '^GRUB_CMDLINE_LINUX_DEFAULT="((?!.*?zswap\.zpool=[A-z]+).*)"'
+    line: 'GRUB_CMDLINE_LINUX_DEFAULT="\1 zswap.zpool={{ zswap_zpool }}"'
+    backrefs: yes
+  notify:
+    - update-grub
+
+- name: set zpool (update)
+  lineinfile:
+    path: '{{ zswap_grubfile }}'
+    regexp: '^GRUB_CMDLINE_LINUX_DEFAULT="(.*?)zswap\.zpool=[A-z]+(.*?)"'
+    line: 'GRUB_CMDLINE_LINUX_DEFAULT="\1zswap.zpool={{ zswap_zpool }}\2"'
+    backrefs: yes
+  notify:
+    - update-grub


### PR DESCRIPTION
This PR add support for managing the following options:

* zswap.accept_threshold_percent
* zswap.zpool
* zswap.compressor

Also it directly applies them without reboot if the user don't disable that explicitly.

Also thanks to @lunarthegrey for preparing some of this.